### PR TITLE
Always use the right directory.

### DIFF
--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
@@ -109,7 +109,8 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
 
     @Override
     public boolean enable() {
-        this.pluginFolder = Paths.get("config", getName());
+        String configFolder = Paths.get(Canary.getWorkingPath(), "config").toString();
+        this.pluginFolder = Paths.get(configFolder, getName());
 
         try {
             this.core = new ServerListPlusCore(this);


### PR DESCRIPTION
This should make sure the config is always in the Canary server dir.
