### PR TITLE
Fix ScheduledCanaryTask.

### DIFF
--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/ScheduledCanaryTask.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/ScheduledCanaryTask.java
@@ -36,6 +36,6 @@ public class ScheduledCanaryTask extends Wrapper<ScheduledFuture<?>> implements 
 
     @Override
     public void cancel() {
-        getHandle().cancel(false);
+        getHandle().cancel(true);
     }
 }


### PR DESCRIPTION
Changed getHandle().cancel(false) to getHandle().cancel(true).

You may have purposely done this, but I don't think you have.
