### PR TITLE
Updates for breaking Velocity API changes.

### DIFF
--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ConsoleCommandSender.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ConsoleCommandSender.java
@@ -19,7 +19,7 @@
 package net.minecrell.serverlistplus.server;
 
 import net.minecrell.serverlistplus.core.plugin.ServerCommandSender;
-import net.minecrell.serverlistplus.server.util.FormattingCodes;
+import net.minecrell.serverlistplus.core.util.FormattingCodes;
 
 public final class ConsoleCommandSender implements ServerCommandSender {
 

--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
@@ -56,7 +56,7 @@ import net.minecrell.serverlistplus.server.status.Favicon;
 import net.minecrell.serverlistplus.server.status.StatusClient;
 import net.minecrell.serverlistplus.server.status.StatusPingResponse;
 import net.minecrell.serverlistplus.server.status.UserProfile;
-import net.minecrell.serverlistplus.server.util.FormattingCodes;
+import net.minecrell.serverlistplus.core.util.FormattingCodes;
 
 import java.awt.image.BufferedImage;
 import java.net.InetSocketAddress;

--- a/Velocity/build.gradle.kts
+++ b/Velocity/build.gradle.kts
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.velocitypowered:velocity-api:1.0-20180825.150317-21")
-    annotationProcessor("com.velocitypowered:velocity-api:1.0-20180825.150317-21")
+    compileOnly("com.velocitypowered:velocity-api:1.0-SNAPSHOT")
+    annotationProcessor("com.velocitypowered:velocity-api:1.0-SNAPSHOT")
 }
 
 java {

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -38,10 +38,9 @@ import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.InboundConnection;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import com.velocitypowered.api.proxy.server.ServerInfo;
+import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import com.velocitypowered.api.util.Favicon;
-import com.velocitypowered.api.util.LegacyChatColorUtils;
 import net.kyori.text.serializer.ComponentSerializers;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.ServerListPlusException;
@@ -58,6 +57,7 @@ import net.minecrell.serverlistplus.core.status.ResponseFetcher;
 import net.minecrell.serverlistplus.core.status.StatusManager;
 import net.minecrell.serverlistplus.core.status.StatusRequest;
 import net.minecrell.serverlistplus.core.status.StatusResponse;
+import net.minecrell.serverlistplus.core.util.FormattingCodes;
 import net.minecrell.serverlistplus.core.util.Helper;
 import net.minecrell.serverlistplus.core.util.Randoms;
 import net.minecrell.serverlistplus.core.util.SnakeYAML;
@@ -295,19 +295,12 @@ public class VelocityPlugin implements ServerListPlusPlugin {
 
     @Override
     public Integer getOnlinePlayers(String location) {
-        Optional<ServerInfo> server = proxy.getServerInfo(location);
+        Optional<RegisteredServer> server = proxy.getServer(location);
         if (!server.isPresent()) {
             return null;
         }
 
-        int count = 0;
-        for (Player player : proxy.getAllPlayers()) {
-            if (player.getCurrentServer().equals(server)) {
-                count++;
-            }
-        }
-
-        return count;
+        return server.get().getPlayersConnected().size();
     }
 
     @Override
@@ -325,16 +318,14 @@ public class VelocityPlugin implements ServerListPlusPlugin {
 
     @Override
     public Iterator<String> getRandomPlayers(String location) {
-        Optional<ServerInfo> server = proxy.getServerInfo(location);
+        Optional<RegisteredServer> server = proxy.getServer(location);
         if (!server.isPresent()) {
             return null;
         }
 
         ArrayList<String> result = new ArrayList<>();
-        for (Player player : proxy.getAllPlayers()) {
-            if (player.getCurrentServer().equals(server)) {
-                result.add(player.getUsername());
-            }
+        for (Player player : server.get().getPlayersConnected()) {
+            result.add(player.getUsername());
         }
 
         return Randoms.shuffle(result).iterator();
@@ -366,7 +357,7 @@ public class VelocityPlugin implements ServerListPlusPlugin {
 
     @Override
     public String colorize(String s) {
-        return LegacyChatColorUtils.translate('&', s);
+        return FormattingCodes.colorize(s);
     }
 
     @Override

--- a/src/main/java/net/minecrell/serverlistplus/core/util/FormattingCodes.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/util/FormattingCodes.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package net.minecrell.serverlistplus.server.util;
+package net.minecrell.serverlistplus.core.util;
 
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
There have been multiple breaking changes in the Velocity API, culminating in build 251. This PR updates ServerListPlus to the new Velocity API.

We now have a type for tracking server data, but lost the ability to colorize text from the Velocity API. To fix that, I imported the code responsible for handling colorization from the standalone server into the common module so the Velocity port can use it.