### PR TITLE
Since 1.13, new lines in encoded favicons are no longer supported.

### DIFF
--- a/Server/src/main/java/net/minecrell/serverlistplus/server/status/Favicon.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/status/Favicon.java
@@ -45,7 +45,7 @@ public final class Favicon {
         ByteBuf buf = Unpooled.buffer();
         try {
             ImageIO.write(image, "PNG", new ByteBufOutputStream(buf));
-            ByteBuf base64 = Base64.encode(buf);
+            ByteBuf base64 = Base64.encode(buf, false);
             try {
                 return FAVICON_PREFIX + base64.toString(Charsets.UTF_8);
             } finally {


### PR DESCRIPTION
Fixes #236 