### PR TITLE
Velocity: Fix reference to legacy serializer due to breaking changes

### DIFF
--- a/Velocity/build.gradle.kts
+++ b/Velocity/build.gradle.kts
@@ -21,8 +21,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.velocitypowered:velocity-api:1.0-SNAPSHOT")
-    annotationProcessor("com.velocitypowered:velocity-api:1.0-SNAPSHOT")
+    compileOnly("com.velocitypowered:velocity-api:1.0.0-SNAPSHOT")
+    annotationProcessor("com.velocitypowered:velocity-api:1.0.0-SNAPSHOT")
 }
 
 java {

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityCommandSender.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityCommandSender.java
@@ -21,7 +21,7 @@ package net.minecrell.serverlistplus.velocity;
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
-import net.kyori.text.serializer.ComponentSerializers;
+import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import net.minecrell.serverlistplus.core.plugin.ServerCommandSender;
 
 class VelocityCommandSender implements ServerCommandSender {
@@ -47,7 +47,7 @@ class VelocityCommandSender implements ServerCommandSender {
     @Override
     @SuppressWarnings("deprecation")
     public void sendMessage(String message) {
-        source.sendMessage(ComponentSerializers.LEGACY.deserialize(message));
+        source.sendMessage(LegacyComponentSerializer.INSTANCE.deserialize(message));
     }
 
     @Override

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -41,7 +41,7 @@ import com.velocitypowered.api.proxy.ProxyServer;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import com.velocitypowered.api.proxy.server.ServerPing;
 import com.velocitypowered.api.util.Favicon;
-import net.kyori.text.serializer.ComponentSerializers;
+import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.ServerListPlusException;
 import net.minecrell.serverlistplus.core.config.PluginConf;
@@ -213,7 +213,7 @@ public class VelocityPlugin implements ServerListPlusPlugin {
 
             // Description
             String message = response.getDescription();
-            if (message != null) builder.description(ComponentSerializers.LEGACY.deserialize(message));
+            if (message != null) builder.description(LegacyComponentSerializer.INSTANCE.deserialize(message));
 
             if (version != null) {
                 // Version name


### PR DESCRIPTION
The `net.kyori.text` dependency in Velocity was updated to `3.0.0`, which refactored the text serializers into their own packages.

This corrects the issue.