### PR TITLE
Remove no longer existing Aquifer page

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ You can download the plugin from these official download sites:
 - [SpigotMC](http://www.spigotmc.org/resources/serverlistplus.241/)
 - [BukkitDev](http://dev.bukkit.org/bukkit-plugins/serverlistplus/) (possibly outdated)
 - [Sponge](https://forums.spongepowered.org/t/7520?u=minecrell)
-- [Aquifer](https://aquifermc.org/resources/serverlistplus.10/)
 - [Development Builds](https://ci.codemc.org/job/Minecrell/job/ServerListPlus/) (unstable, not recommended)
 
 ## Compilation


### PR DESCRIPTION
The Aquifer page no longer exists (Was rebranded to PaperMC Forums) and searching on the new forum didn't show any result for ServerListPlus.