### PR TITLE
Mention SLPs move to maintenance-only stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ServerListPlus
 
+> ## Important Notice
+> ServerListPlus is no longer receiving new features and only gets updates to fix bugs or compatability issues at most.  
+> A list of maintained open-source alternatives for SLP can be found in [issue #338](https://github.com/Minecrell/ServerListPlus/issues/338).
+
 [ServerListPlus](http://git.io/slp) is an extremely customizable server status ping plugin for Minecraft. It provides an easy-to-use configuration for almost everything possible using the server status ping. The plugin aims to become the universal solution for server status ping customization, available for Bukkit/Spigot, Canary, Sponge and for BungeeCord servers.
 
 ## Features


### PR DESCRIPTION
This PR adds a note to the readme, that SLP has entered a "maintenance only" stage, meaning it only receives (at most) bug fixes and compatibility fixes.

I decided to make this PR since [Minecrell mentioned](https://github.com/Minecrell/ServerListPlus/pull/311#issuecomment-826357456) that he would mention issue #338 at one point in the README, so this takes some work from his shoulders. :)

If there are any corrections needed (including grammar), let me know.