### PR TITLE
Create FaviconCache class to reduce code duplication

### DIFF
--- a/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
+++ b/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
@@ -23,7 +23,6 @@ import static net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger
 import static net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger.INFO;
 import static net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger.WARN;
 
-import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
@@ -323,8 +322,8 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     }
 
     @Override
-    public LoadingCache<FaviconSource, Optional<CachedServerIcon>> getFaviconCache() {
-        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
+    public FaviconCache<?> getFaviconCache() {
+        return faviconCache;
     }
 
     @Override

--- a/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
+++ b/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
@@ -43,7 +43,7 @@ import net.minecrell.serverlistplus.core.ServerListPlusException;
 import net.minecrell.serverlistplus.core.config.CoreConf;
 import net.minecrell.serverlistplus.core.config.PluginConf;
 import net.minecrell.serverlistplus.core.config.storage.InstanceStorage;
-import net.minecrell.serverlistplus.core.favicon.FaviconHelper;
+import net.minecrell.serverlistplus.core.favicon.FaviconCache;
 import net.minecrell.serverlistplus.core.favicon.FaviconSource;
 import net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger;
 import net.minecrell.serverlistplus.core.logging.ServerListPlusLogger;
@@ -86,18 +86,7 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     private StatusHandler bukkit, protocol;
     private Listener loginListener, disconnectListener;
 
-    // Favicon cache
-    private final CacheLoader<FaviconSource, Optional<CachedServerIcon>> faviconLoader =
-            new CacheLoader<FaviconSource, Optional<CachedServerIcon>>() {
-                @Override
-                public Optional<CachedServerIcon> load(FaviconSource source) throws Exception {
-                    // Try loading the favicon
-                    BufferedImage image = FaviconHelper.loadSafely(core, source);
-                    if (image == null) return Optional.absent(); // Favicon loading failed
-                    else return Optional.of(getServer().loadServerIcon(image)); // Success!
-                }
-            };
-    private LoadingCache<FaviconSource, Optional<CachedServerIcon>> faviconCache;
+    private FaviconCache<CachedServerIcon> faviconCache;
 
     // Request cache
     private final CacheLoader<InetSocketAddress, StatusRequest> requestLoader =
@@ -280,7 +269,7 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     }
 
     public CachedServerIcon getFavicon(FaviconSource source) {
-        return faviconCache.getUnchecked(source).orNull();
+        return faviconCache.get(source).orNull();
     }
 
     @Override
@@ -335,7 +324,7 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
 
     @Override
     public LoadingCache<FaviconSource, Optional<CachedServerIcon>> getFaviconCache() {
-        return faviconCache;
+        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
     }
 
     @Override
@@ -396,12 +385,16 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            this.faviconCache = CacheBuilder.from(spec).build(faviconLoader);
+            faviconCache = new FaviconCache<CachedServerIcon>(core, spec) {
+                @Override
+                protected CachedServerIcon createFavicon(BufferedImage image) throws Exception {
+                    return getServer().loadServerIcon(image);
+                }
+            };
         } else {
             // Delete favicon cache
-            faviconCache.invalidateAll();
-            faviconCache.cleanUp();
-            this.faviconCache = null;
+            faviconCache.clear();
+            faviconCache = null;
         }
     }
 

--- a/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
+++ b/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
@@ -85,7 +85,12 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     private StatusHandler bukkit, protocol;
     private Listener loginListener, disconnectListener;
 
-    private FaviconCache<CachedServerIcon> faviconCache;
+    private final FaviconCache<CachedServerIcon> faviconCache = new FaviconCache<CachedServerIcon>() {
+        @Override
+        protected CachedServerIcon createFavicon(BufferedImage image) throws Exception {
+            return getServer().loadServerIcon(image);
+        }
+    };
 
     // Request cache
     private final CacheLoader<InetSocketAddress, StatusRequest> requestLoader =
@@ -154,6 +159,8 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
             getLogger().log(ERROR, "An internal error occurred while loading the core!", e);
             disablePlugin(); return; // Disable bukkit to show error in /plugins
         }
+
+        faviconCache.setCore(core);
 
         // Register commands
         getCommand("serverlistplus").setExecutor(new ServerListPlusCommand());
@@ -384,16 +391,10 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            faviconCache = new FaviconCache<CachedServerIcon>(core, spec) {
-                @Override
-                protected CachedServerIcon createFavicon(BufferedImage image) throws Exception {
-                    return getServer().loadServerIcon(image);
-                }
-            };
+            faviconCache.reload(spec);
         } else {
             // Delete favicon cache
             faviconCache.clear();
-            faviconCache = null;
         }
     }
 

--- a/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
+++ b/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
@@ -85,12 +85,7 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     private StatusHandler bukkit, protocol;
     private Listener loginListener, disconnectListener;
 
-    private final FaviconCache<CachedServerIcon> faviconCache = new FaviconCache<CachedServerIcon>() {
-        @Override
-        protected CachedServerIcon createFavicon(BufferedImage image) throws Exception {
-            return getServer().loadServerIcon(image);
-        }
-    };
+    private FaviconCache<CachedServerIcon> faviconCache;
 
     // Request cache
     private final CacheLoader<InetSocketAddress, StatusRequest> requestLoader =
@@ -159,8 +154,6 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
             getLogger().log(ERROR, "An internal error occurred while loading the core!", e);
             disablePlugin(); return; // Disable bukkit to show error in /plugins
         }
-
-        faviconCache.setCore(core);
 
         // Register commands
         getCommand("serverlistplus").setExecutor(new ServerListPlusCommand());
@@ -389,12 +382,16 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     }
 
     @Override
-    public void reloadFaviconCache(CacheBuilderSpec spec) {
-        if (spec != null) {
-            faviconCache.reload(spec);
+    public void createFaviconCache(CacheBuilderSpec spec) {
+        if (faviconCache == null) {
+            faviconCache = new FaviconCache<CachedServerIcon>(core, spec) {
+                @Override
+                protected CachedServerIcon createFavicon(BufferedImage image) throws Exception {
+                    return getServer().loadServerIcon(image);
+                }
+            };
         } else {
-            // Delete favicon cache
-            faviconCache.clear();
+            faviconCache.reload(spec);
         }
     }
 

--- a/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
+++ b/Bukkit/src/main/java/net/minecrell/serverlistplus/bukkit/BukkitPlugin.java
@@ -384,7 +384,7 @@ public class BukkitPlugin extends BukkitPluginBase implements ServerListPlusPlug
     @Override
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
-            faviconCache = new FaviconCache<CachedServerIcon>(core, spec) {
+            faviconCache = new FaviconCache<CachedServerIcon>(this, spec) {
                 @Override
                 protected CachedServerIcon createFavicon(BufferedImage image) throws Exception {
                     return getServer().loadServerIcon(image);

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -76,7 +76,11 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     private RGBFormat rgbFormat = RGBFormat.UNSUPPORTED;
     private Listener connectionListener, pingListener;
 
-    private FaviconCache<Favicon> faviconCache;
+    private final FaviconCache<Favicon> faviconCache = new FaviconCache<Favicon>() {
+        @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
+            return Favicon.create(image);
+        }
+    };;
 
     private boolean isPluginLoaded(String pluginName) {
         return getProxy().getPluginManager().getPlugin(pluginName) != null;
@@ -99,6 +103,8 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
             getLogger().log(ERROR, "An internal error occurred while loading the core.", e);
             return;
         }
+
+        faviconCache.setCore(core);
 
         // Register commands
         getProxy().getPluginManager().registerCommand(this, new ServerListPlusCommand());
@@ -372,15 +378,10 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            faviconCache = new FaviconCache<Favicon>(core, spec) {
-                @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
-                    return Favicon.create(image);
-                }
-            };
+            faviconCache.reload(spec);
         } else {
             // Delete favicon cache
             faviconCache.clear();
-            faviconCache = null;
         }
     }
 

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -25,7 +25,6 @@ import static net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.LoadingCache;
 import net.md_5.bungee.api.AbstractReconnectHandler;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.CommandSender;
@@ -336,8 +335,8 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     }
 
     @Override
-    public LoadingCache<FaviconSource, Optional<Favicon>> getFaviconCache() {
-        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
+    public FaviconCache<?> getFaviconCache() {
+        return faviconCache;
     }
 
     @Override

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -251,10 +251,8 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
                     // Load favicon asynchronously
                     event.registerIntent(BungeePlugin.this);
                     getProxy().getScheduler().runAsync(BungeePlugin.this, new AsyncFaviconLoader(event, favicon));
-                } else {
-                    if (icon.isPresent()) {
-                        ping.setFavicon(icon.get());
-                    }
+                } else if (icon.isPresent()) {
+                    ping.setFavicon(icon.get());
                 }
             }
         }
@@ -370,7 +368,8 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
             faviconCache = new FaviconCache<Favicon>(this, spec) {
-                @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
+                @Override
+                protected Favicon createFavicon(BufferedImage image) throws Exception {
                     return Favicon.create(image);
                 }
             };

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -369,7 +369,7 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     @Override
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
-            faviconCache = new FaviconCache<Favicon>(core, spec) {
+            faviconCache = new FaviconCache<Favicon>(this, spec) {
                 @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
                     return Favicon.create(image);
                 }

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -33,7 +33,6 @@ import net.md_5.bungee.api.ServerPing;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
-import net.md_5.bungee.api.event.AsyncEvent;
 import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.event.PlayerDisconnectEvent;
 import net.md_5.bungee.api.event.ProxyPingEvent;
@@ -247,9 +246,8 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
             if (favicon == FaviconSource.NONE) {
                 ping.setFavicon((Favicon) null);
             } else if (favicon != null) {
-                Optional<Favicon> icon;
-                // Check if instanceof AsyncEvent for compatibility with 1.7.10
-                if (event instanceof AsyncEvent && !faviconCache.contains(favicon)) {
+                Optional<Favicon> icon = faviconCache.getIfPresent(favicon);
+                if (icon == null) {
                     // Load favicon asynchronously
                     event.registerIntent(BungeePlugin.this);
                     getProxy().getScheduler().runAsync(BungeePlugin.this, new AsyncFaviconLoader(event, favicon));

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -252,7 +252,6 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
                     event.registerIntent(BungeePlugin.this);
                     getProxy().getScheduler().runAsync(BungeePlugin.this, new AsyncFaviconLoader(event, favicon));
                 } else {
-                    icon = faviconCache.get(favicon);
                     if (icon.isPresent()) {
                         ping.setFavicon(icon.get());
                     }

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -24,9 +24,7 @@ import static net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger
 
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import net.md_5.bungee.api.AbstractReconnectHandler;
 import net.md_5.bungee.api.ChatColor;
@@ -49,7 +47,7 @@ import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.ServerListPlusException;
 import net.minecrell.serverlistplus.core.config.PluginConf;
 import net.minecrell.serverlistplus.core.config.storage.InstanceStorage;
-import net.minecrell.serverlistplus.core.favicon.FaviconHelper;
+import net.minecrell.serverlistplus.core.favicon.FaviconCache;
 import net.minecrell.serverlistplus.core.favicon.FaviconSource;
 import net.minecrell.serverlistplus.core.logging.JavaServerListPlusLogger;
 import net.minecrell.serverlistplus.core.logging.ServerListPlusLogger;
@@ -79,18 +77,7 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     private RGBFormat rgbFormat = RGBFormat.UNSUPPORTED;
     private Listener connectionListener, pingListener;
 
-    // Favicon cache
-    private final CacheLoader<FaviconSource, Optional<Favicon>> faviconLoader =
-            new CacheLoader<FaviconSource, Optional<Favicon>>() {
-        @Override
-        public Optional<Favicon> load(FaviconSource source) throws Exception {
-            // Try loading the favicon
-            BufferedImage image = FaviconHelper.loadSafely(core, source);
-            if (image == null) return Optional.absent(); // Favicon loading failed
-            else return Optional.of(Favicon.create(image)); // Success!
-        }
-    };
-    private LoadingCache<FaviconSource, Optional<Favicon>> faviconCache;
+    private FaviconCache<Favicon> faviconCache;
 
     private boolean isPluginLoaded(String pluginName) {
         return getProxy().getPluginManager().getPlugin(pluginName) != null;
@@ -263,18 +250,15 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
             } else if (favicon != null) {
                 Optional<Favicon> icon;
                 // Check if instanceof AsyncEvent for compatibility with 1.7.10
-                if (event instanceof AsyncEvent) {
-                    icon = faviconCache.getIfPresent(favicon);
-                } else {
-                    icon = faviconCache.getUnchecked(favicon);
-                }
-
-                if (icon == null) {
+                if (event instanceof AsyncEvent && !faviconCache.contains(favicon)) {
                     // Load favicon asynchronously
                     event.registerIntent(BungeePlugin.this);
                     getProxy().getScheduler().runAsync(BungeePlugin.this, new AsyncFaviconLoader(event, favicon));
-                } else if (icon.isPresent()) {
-                    ping.setFavicon(icon.get());
+                } else {
+                    icon = faviconCache.get(favicon);
+                    if (icon.isPresent()) {
+                        ping.setFavicon(icon.get());
+                    }
                 }
             }
         }
@@ -292,7 +276,7 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
 
         @Override
         public void run() {
-            Optional<Favicon> favicon = faviconCache.getUnchecked(this.source);
+            Optional<Favicon> favicon = faviconCache.get(this.source);
             if (favicon.isPresent()) {
                 event.getResponse().setFavicon(favicon.get());
             }
@@ -353,7 +337,7 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
 
     @Override
     public LoadingCache<FaviconSource, Optional<Favicon>> getFaviconCache() {
-        return faviconCache;
+        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
     }
 
     @Override
@@ -389,12 +373,15 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            this.faviconCache = CacheBuilder.from(spec).build(faviconLoader);
+            faviconCache = new FaviconCache<Favicon>(core, spec) {
+                @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
+                    return Favicon.create(image);
+                }
+            };
         } else {
             // Delete favicon cache
-            faviconCache.invalidateAll();
-            faviconCache.cleanUp();
-            this.faviconCache = null;
+            faviconCache.clear();
+            faviconCache = null;
         }
     }
 

--- a/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
+++ b/Bungee/src/main/java/net/minecrell/serverlistplus/bungee/BungeePlugin.java
@@ -76,11 +76,7 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     private RGBFormat rgbFormat = RGBFormat.UNSUPPORTED;
     private Listener connectionListener, pingListener;
 
-    private final FaviconCache<Favicon> faviconCache = new FaviconCache<Favicon>() {
-        @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
-            return Favicon.create(image);
-        }
-    };;
+    private FaviconCache<Favicon> faviconCache;
 
     private boolean isPluginLoaded(String pluginName) {
         return getProxy().getPluginManager().getPlugin(pluginName) != null;
@@ -103,8 +99,6 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
             getLogger().log(ERROR, "An internal error occurred while loading the core.", e);
             return;
         }
-
-        faviconCache.setCore(core);
 
         // Register commands
         getProxy().getPluginManager().registerCommand(this, new ServerListPlusCommand());
@@ -376,12 +370,15 @@ public class BungeePlugin extends BungeePluginBase implements ServerListPlusPlug
     }
 
     @Override
-    public void reloadFaviconCache(CacheBuilderSpec spec) {
-        if (spec != null) {
-            faviconCache.reload(spec);
+    public void createFaviconCache(CacheBuilderSpec spec) {
+        if (faviconCache == null) {
+            faviconCache = new FaviconCache<Favicon>(core, spec) {
+                @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
+                    return Favicon.create(image);
+                }
+            };
         } else {
-            // Delete favicon cache
-            faviconCache.clear();
+            faviconCache.reload(spec);
         }
     }
 

--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
@@ -83,7 +83,12 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
 
     private final Field PROFILES_FIELD;
 
-    private FaviconCache<String> faviconCache;
+    private final FaviconCache<String> faviconCache = new FaviconCache<String>() {
+        @Override
+        protected String createFavicon(BufferedImage image) throws Exception {
+            return CanaryFavicon.create(image);
+        }
+    };
 
     private static void loadJAR(Path path) throws Exception {
         Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
@@ -119,6 +124,8 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
             getLogman().error("An internal error occurred while loading the core.", e);
             return false;
         }
+
+        faviconCache.setCore(core);
 
         // Register command
         try {
@@ -329,15 +336,10 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            faviconCache = new FaviconCache<String>(core, spec) {
-                @Override protected String createFavicon(BufferedImage image) throws Exception {
-                    return CanaryFavicon.create(image);
-                }
-            };
+            faviconCache.reload(spec);
         } else {
             // Delete favicon cache
             faviconCache.clear();
-            faviconCache = null;
         }
     }
 

--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
@@ -21,7 +21,6 @@ package net.minecrell.serverlistplus.canary;
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.LoadingCache;
 import com.mojang.authlib.GameProfile;
 import lombok.SneakyThrows;
 import net.canarymod.Canary;
@@ -291,8 +290,8 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
     }
 
     @Override
-    public LoadingCache<FaviconSource, ?> getFaviconCache() {
-        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
+    public FaviconCache<?> getFaviconCache() {
+        return faviconCache;
     }
 
     @Override

--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
@@ -329,7 +329,7 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
     @Override
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
-            faviconCache = new FaviconCache<String>(core, spec) {
+            faviconCache = new FaviconCache<String>(this, spec) {
                 @Override
                 protected String createFavicon(BufferedImage image) throws Exception {
                     return CanaryFavicon.create(image);

--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
@@ -83,12 +83,7 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
 
     private final Field PROFILES_FIELD;
 
-    private final FaviconCache<String> faviconCache = new FaviconCache<String>() {
-        @Override
-        protected String createFavicon(BufferedImage image) throws Exception {
-            return CanaryFavicon.create(image);
-        }
-    };
+    private FaviconCache<String> faviconCache;
 
     private static void loadJAR(Path path) throws Exception {
         Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
@@ -124,8 +119,6 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
             getLogman().error("An internal error occurred while loading the core.", e);
             return false;
         }
-
-        faviconCache.setCore(core);
 
         // Register command
         try {
@@ -334,12 +327,16 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
     }
 
     @Override
-    public void reloadFaviconCache(CacheBuilderSpec spec) {
-        if (spec != null) {
-            faviconCache.reload(spec);
+    public void createFaviconCache(CacheBuilderSpec spec) {
+        if (faviconCache == null) {
+            faviconCache = new FaviconCache<String>(core, spec) {
+                @Override
+                protected String createFavicon(BufferedImage image) throws Exception {
+                    return CanaryFavicon.create(image);
+                }
+            };
         } else {
-            // Delete favicon cache
-            faviconCache.clear();
+            faviconCache.reload(spec);
         }
     }
 

--- a/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
+++ b/Canary/src/main/java/net/minecrell/serverlistplus/canary/CanaryPlugin.java
@@ -20,9 +20,7 @@ package net.minecrell.serverlistplus.canary;
 
 import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.mojang.authlib.GameProfile;
 import lombok.SneakyThrows;
@@ -44,7 +42,7 @@ import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.ServerListPlusException;
 import net.minecrell.serverlistplus.core.config.PluginConf;
 import net.minecrell.serverlistplus.core.config.storage.InstanceStorage;
-import net.minecrell.serverlistplus.core.favicon.FaviconHelper;
+import net.minecrell.serverlistplus.core.favicon.FaviconCache;
 import net.minecrell.serverlistplus.core.favicon.FaviconSource;
 import net.minecrell.serverlistplus.core.logging.Log4j2ServerListPlusLogger;
 import net.minecrell.serverlistplus.core.logging.ServerListPlusLogger;
@@ -86,18 +84,7 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
 
     private final Field PROFILES_FIELD;
 
-    // Favicon cache
-    private final CacheLoader<FaviconSource, Optional<String>> faviconLoader =
-            new CacheLoader<FaviconSource, Optional<String>>() {
-                @Override
-                public Optional<String> load(FaviconSource source) throws Exception {
-                    // Try loading the favicon
-                    BufferedImage image = FaviconHelper.loadSafely(core, source);
-                    if (image == null) return Optional.absent(); // Favicon loading failed
-                    else return Optional.of(CanaryFavicon.create(image)); // Success!
-                }
-            };
-    private LoadingCache<FaviconSource, Optional<String>> faviconCache;
+    private FaviconCache<String> faviconCache;
 
     private static void loadJAR(Path path) throws Exception {
         Method method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
@@ -214,7 +201,7 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
             if (favicon == FaviconSource.NONE) {
                 //hook.setFavicon(null); // FIXME (in Canary): Would cause a NPE
             } else if (favicon != null) {
-                Optional<String> icon = faviconCache.getUnchecked(favicon);
+                Optional<String> icon = faviconCache.get(favicon);
                 if (icon.isPresent()) hook.setFavicon(icon.get());
             }
 
@@ -305,7 +292,7 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
 
     @Override
     public LoadingCache<FaviconSource, ?> getFaviconCache() {
-        return faviconCache;
+        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
     }
 
     @Override
@@ -343,12 +330,15 @@ public class CanaryPlugin extends Plugin implements ServerListPlusPlugin {
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            this.faviconCache = CacheBuilder.from(spec).build(faviconLoader);
+            faviconCache = new FaviconCache<String>(core, spec) {
+                @Override protected String createFavicon(BufferedImage image) throws Exception {
+                    return CanaryFavicon.create(image);
+                }
+            };
         } else {
             // Delete favicon cache
-            faviconCache.invalidateAll();
-            faviconCache.cleanUp();
-            this.faviconCache = null;
+            faviconCache.clear();
+            faviconCache = null;
         }
     }
 

--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
@@ -225,7 +225,8 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
         FaviconSource favicon = response.getFavicon();
         if (favicon != null && favicon != FaviconSource.NONE) {
             Optional<String> icon = faviconCache.get(favicon).toJavaUtil();
-            icon.ifPresent(ping::setFavicon);
+            if (icon.isPresent())
+                ping.setFavicon(icon.get());
         }
 
         if (response.hidePlayers()) {

--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
@@ -90,12 +90,7 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
     private boolean playerTracking;
     private ImmutableList<String> loginMessages;
 
-    private final FaviconCache<String> faviconCache = new FaviconCache<String>() {
-        @Override
-        protected String createFavicon(BufferedImage image) throws Exception {
-            return Favicon.create(image);
-        }
-    };
+    private FaviconCache<String> faviconCache;
 
     public ServerListPlusServer() throws UnknownHostException {
         checkState(instance == null, "Server was already initialized");
@@ -106,8 +101,6 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
         logger.info("Loading...");
         ServerListPlusLogger clogger = new Log4j2ServerListPlusLogger(LogManager.getLogger(ServerListPlusCore.class), null);
         this.core = new ServerListPlusCore(this, clogger, new ServerProfileManager());
-
-        faviconCache.setCore(core);
 
         ServerConf conf = this.core.getConf(ServerConf.class);
         this.network = new NetworkManager(this, Netty.parseAddress(conf.Address));
@@ -384,12 +377,16 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
     }
 
     @Override
-    public void reloadFaviconCache(CacheBuilderSpec spec) {
-        if (spec != null) {
-            faviconCache.reload(spec);
+    public void createFaviconCache(CacheBuilderSpec spec) {
+        if (faviconCache == null) {
+            faviconCache = new FaviconCache<String>(core, spec) {
+                @Override
+                protected String createFavicon(BufferedImage image) throws Exception {
+                    return Favicon.create(image);
+                }
+            };
         } else {
-            // Delete favicon cache
-            faviconCache.clear();
+            faviconCache.reload(spec);
         }
     }
 

--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
@@ -380,7 +380,7 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
     @Override
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
-            faviconCache = new FaviconCache<String>(core, spec) {
+            faviconCache = new FaviconCache<String>(this, spec) {
                 @Override
                 protected String createFavicon(BufferedImage image) throws Exception {
                     return Favicon.create(image);

--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import net.kyori.adventure.text.Component;
@@ -343,8 +342,8 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
     }
 
     @Override
-    public LoadingCache<FaviconSource, com.google.common.base.Optional<String>> getFaviconCache() {
-        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
+    public FaviconCache<?> getFaviconCache() {
+        return faviconCache;
     }
 
     @Override

--- a/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
+++ b/Server/src/main/java/net/minecrell/serverlistplus/server/ServerListPlusServer.java
@@ -20,6 +20,7 @@ package net.minecrell.serverlistplus.server;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.collect.ImmutableList;
@@ -65,7 +66,6 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -224,7 +224,7 @@ public final class ServerListPlusServer implements ServerListPlusPlugin {
         // Favicon
         FaviconSource favicon = response.getFavicon();
         if (favicon != null && favicon != FaviconSource.NONE) {
-            Optional<String> icon = faviconCache.get(favicon).toJavaUtil();
+            Optional<String> icon = faviconCache.get(favicon);
             if (icon.isPresent())
                 ping.setFavicon(icon.get());
         }

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -379,7 +379,7 @@ public class SpongePlugin implements ServerListPlusPlugin {
     @Override
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
-            faviconCache = new FaviconCache<Favicon>(core, spec) {
+            faviconCache = new FaviconCache<Favicon>(this, spec) {
                 @Override
                 protected Favicon createFavicon(BufferedImage image) throws Exception {
                     return game.getRegistry().loadFavicon(image);

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -23,7 +23,6 @@ import static org.spongepowered.api.Platform.Component.IMPLEMENTATION;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.LoadingCache;
 import com.google.inject.Inject;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.ServerListPlusException;
@@ -341,8 +340,8 @@ public class SpongePlugin implements ServerListPlusPlugin {
     }
 
     @Override
-    public LoadingCache<FaviconSource, ?> getFaviconCache() {
-        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
+    public FaviconCache<?> getFaviconCache() {
+        return faviconCache;
     }
 
     @Override

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -235,7 +235,7 @@ public class SpongePlugin implements ServerListPlusPlugin {
             if (favicon == FaviconSource.NONE) {
                 ping.setFavicon(null);
             } else if (favicon != null) {
-                Optional<Favicon> icon = faviconCache.get(favicon).toJavaUtil();
+                com.google.common.base.Optional<Favicon> icon = faviconCache.get(favicon);
                 if (icon.isPresent())
                     ping.setFavicon(icon.get());
             }

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -99,7 +99,12 @@ public class SpongePlugin implements ServerListPlusPlugin {
 
     private Object loginListener, pingListener;
 
-    private FaviconCache<Favicon> faviconCache;
+    private final FaviconCache<Favicon> faviconCache = new FaviconCache<Favicon>() {
+        @Override
+        protected Favicon createFavicon(BufferedImage image) throws Exception {
+            return game.getRegistry().loadFavicon(image);
+        }
+    };
 
     @Inject
     public SpongePlugin(PluginManager pluginManager) {
@@ -124,6 +129,8 @@ public class SpongePlugin implements ServerListPlusPlugin {
             logger.error("An internal error occurred while loading the core.", e);
             return;
         }
+
+        faviconCache.setCore(core);
 
         game.getCommandManager().register(this, new ServerListPlusCommand(), "serverlistplus", "slp");
 
@@ -378,16 +385,10 @@ public class SpongePlugin implements ServerListPlusPlugin {
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            faviconCache = new FaviconCache<Favicon>(core, spec) {
-                @Override
-                protected Favicon createFavicon(BufferedImage image) throws Exception {
-                    return game.getRegistry().loadFavicon(image);
-                }
-            };
+            faviconCache.reload(spec);
         } else {
             // Delete favicon cache
             faviconCache.clear();
-            faviconCache = null;
         }
     }
 

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -99,12 +99,7 @@ public class SpongePlugin implements ServerListPlusPlugin {
 
     private Object loginListener, pingListener;
 
-    private final FaviconCache<Favicon> faviconCache = new FaviconCache<Favicon>() {
-        @Override
-        protected Favicon createFavicon(BufferedImage image) throws Exception {
-            return game.getRegistry().loadFavicon(image);
-        }
-    };
+    private FaviconCache<Favicon> faviconCache;
 
     @Inject
     public SpongePlugin(PluginManager pluginManager) {
@@ -129,8 +124,6 @@ public class SpongePlugin implements ServerListPlusPlugin {
             logger.error("An internal error occurred while loading the core.", e);
             return;
         }
-
-        faviconCache.setCore(core);
 
         game.getCommandManager().register(this, new ServerListPlusCommand(), "serverlistplus", "slp");
 
@@ -383,12 +376,16 @@ public class SpongePlugin implements ServerListPlusPlugin {
     }
 
     @Override
-    public void reloadFaviconCache(CacheBuilderSpec spec) {
-        if (spec != null) {
-            faviconCache.reload(spec);
+    public void createFaviconCache(CacheBuilderSpec spec) {
+        if (faviconCache == null) {
+            faviconCache = new FaviconCache<Favicon>(core, spec) {
+                @Override
+                protected Favicon createFavicon(BufferedImage image) throws Exception {
+                    return game.getRegistry().loadFavicon(image);
+                }
+            };
         } else {
-            // Delete favicon cache
-            faviconCache.clear();
+            faviconCache.reload(spec);
         }
     }
 

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -22,16 +22,14 @@ import static org.spongepowered.api.Platform.Component.API;
 import static org.spongepowered.api.Platform.Component.IMPLEMENTATION;
 
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.inject.Inject;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.ServerListPlusException;
 import net.minecrell.serverlistplus.core.config.PluginConf;
 import net.minecrell.serverlistplus.core.config.storage.InstanceStorage;
-import net.minecrell.serverlistplus.core.favicon.FaviconHelper;
+import net.minecrell.serverlistplus.core.favicon.FaviconCache;
 import net.minecrell.serverlistplus.core.favicon.FaviconSource;
 import net.minecrell.serverlistplus.core.logging.ServerListPlusLogger;
 import net.minecrell.serverlistplus.core.logging.Slf4jServerListPlusLogger;
@@ -102,18 +100,7 @@ public class SpongePlugin implements ServerListPlusPlugin {
 
     private Object loginListener, pingListener;
 
-    // Favicon cache
-    private final CacheLoader<FaviconSource, Optional<Favicon>> faviconLoader =
-            new CacheLoader<FaviconSource, Optional<Favicon>>() {
-                @Override
-                public Optional<Favicon> load(FaviconSource source) throws Exception {
-                    // Try loading the favicon
-                    BufferedImage image = FaviconHelper.loadSafely(core, source);
-                    if (image == null) return Optional.empty(); // Favicon loading failed
-                    else return Optional.of(game.getRegistry().loadFavicon(image)); // Success!
-                }
-            };
-    private LoadingCache<FaviconSource, Optional<Favicon>> faviconCache;
+    private FaviconCache<Favicon> faviconCache;
 
     @Inject
     public SpongePlugin(PluginManager pluginManager) {
@@ -249,7 +236,7 @@ public class SpongePlugin implements ServerListPlusPlugin {
             if (favicon == FaviconSource.NONE) {
                 ping.setFavicon(null);
             } else if (favicon != null) {
-                Optional<Favicon> icon = faviconCache.getUnchecked(favicon);
+                Optional<Favicon> icon = faviconCache.get(favicon).toJavaUtil();
                 icon.ifPresent(ping::setFavicon);
             }
 
@@ -355,7 +342,7 @@ public class SpongePlugin implements ServerListPlusPlugin {
 
     @Override
     public LoadingCache<FaviconSource, ?> getFaviconCache() {
-        return faviconCache;
+        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
     }
 
     @Override
@@ -392,12 +379,16 @@ public class SpongePlugin implements ServerListPlusPlugin {
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            this.faviconCache = CacheBuilder.from(spec).build(faviconLoader);
+            faviconCache = new FaviconCache<Favicon>(core, spec) {
+                @Override
+                protected Favicon createFavicon(BufferedImage image) throws Exception {
+                    return game.getRegistry().loadFavicon(image);
+                }
+            };
         } else {
             // Delete favicon cache
-            faviconCache.invalidateAll();
-            faviconCache.cleanUp();
-            this.faviconCache = null;
+            faviconCache.clear();
+            faviconCache = null;
         }
     }
 

--- a/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
+++ b/Sponge/src/main/java/net/minecrell/serverlistplus/sponge/SpongePlugin.java
@@ -236,7 +236,8 @@ public class SpongePlugin implements ServerListPlusPlugin {
                 ping.setFavicon(null);
             } else if (favicon != null) {
                 Optional<Favicon> icon = faviconCache.get(favicon).toJavaUtil();
-                icon.ifPresent(ping::setFavicon);
+                if (icon.isPresent())
+                    ping.setFavicon(icon.get());
             }
 
             if (players != null) {

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -20,7 +20,6 @@ package net.minecrell.serverlistplus.velocity;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.LoadingCache;
 import com.google.inject.Inject;
 import com.velocitypowered.api.command.SimpleCommand;
 import com.velocitypowered.api.event.EventHandler;
@@ -323,8 +322,8 @@ public class VelocityPlugin implements ServerListPlusPlugin {
     }
 
     @Override
-    public LoadingCache<FaviconSource, com.google.common.base.Optional<Favicon>> getFaviconCache() {
-        return (faviconCache == null) ? null : faviconCache.getLoadingCache();
+    public FaviconCache<?> getFaviconCache() {
+        return faviconCache;
     }
 
     @Override

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -84,7 +84,12 @@ public class VelocityPlugin implements ServerListPlusPlugin {
     private EventHandler<ProxyPingEvent> pingListener;
     private Object connectionListener;
 
-    private FaviconCache<Favicon> faviconCache;
+    private final FaviconCache<Favicon> faviconCache = new FaviconCache<Favicon>() {
+        @Override
+        protected Favicon createFavicon(BufferedImage image) throws Exception {
+            return Favicon.create(image);
+        }
+    };
 
     @Inject
     public VelocityPlugin(Logger logger, ProxyServer proxy, @DataDirectory Path pluginFolder) {
@@ -106,6 +111,8 @@ public class VelocityPlugin implements ServerListPlusPlugin {
             logger.error("An internal error occurred while loading the core.", e);
             return;
         }
+
+        faviconCache.setCore(core);
 
         // Register commands
         this.proxy.getCommandManager().register("serverlistplus", new ServerListPlusCommand(), "slp");
@@ -363,15 +370,10 @@ public class VelocityPlugin implements ServerListPlusPlugin {
     @Override
     public void reloadFaviconCache(CacheBuilderSpec spec) {
         if (spec != null) {
-            faviconCache = new FaviconCache<Favicon>(core, spec) {
-                @Override protected Favicon createFavicon(BufferedImage image) throws Exception {
-                    return Favicon.create(image);
-                }
-            };
+            faviconCache.reload(spec);
         } else {
             // Delete favicon cache
             faviconCache.clear();
-            faviconCache = null;
         }
     }
 

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -250,7 +250,8 @@ public class VelocityPlugin implements ServerListPlusPlugin {
                 builder.clearFavicon();
             } else if (favicon != null) {
                 Optional<Favicon> icon = faviconCache.get(favicon).toJavaUtil();
-                icon.ifPresent(builder::favicon);
+                if (icon.isPresent())
+                    builder.favicon(icon.get());
             }
 
             event.setPing(builder.build());

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -249,7 +249,7 @@ public class VelocityPlugin implements ServerListPlusPlugin {
             if (favicon == FaviconSource.NONE) {
                 builder.clearFavicon();
             } else if (favicon != null) {
-                Optional<Favicon> icon = faviconCache.get(favicon).toJavaUtil();
+                com.google.common.base.Optional<Favicon> icon = faviconCache.get(favicon);
                 if (icon.isPresent())
                     builder.favicon(icon.get());
             }

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -364,7 +364,7 @@ public class VelocityPlugin implements ServerListPlusPlugin {
     @Override
     public void createFaviconCache(CacheBuilderSpec spec) {
         if (faviconCache == null) {
-            faviconCache = new FaviconCache<Favicon>(core, spec) {
+            faviconCache = new FaviconCache<Favicon>(this, spec) {
                 @Override
                 protected Favicon createFavicon(BufferedImage image) throws Exception {
                     return Favicon.create(image);

--- a/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
+++ b/Velocity/src/main/java/net/minecrell/serverlistplus/velocity/VelocityPlugin.java
@@ -84,12 +84,7 @@ public class VelocityPlugin implements ServerListPlusPlugin {
     private EventHandler<ProxyPingEvent> pingListener;
     private Object connectionListener;
 
-    private final FaviconCache<Favicon> faviconCache = new FaviconCache<Favicon>() {
-        @Override
-        protected Favicon createFavicon(BufferedImage image) throws Exception {
-            return Favicon.create(image);
-        }
-    };
+    private FaviconCache<Favicon> faviconCache;
 
     @Inject
     public VelocityPlugin(Logger logger, ProxyServer proxy, @DataDirectory Path pluginFolder) {
@@ -111,8 +106,6 @@ public class VelocityPlugin implements ServerListPlusPlugin {
             logger.error("An internal error occurred while loading the core.", e);
             return;
         }
-
-        faviconCache.setCore(core);
 
         // Register commands
         this.proxy.getCommandManager().register("serverlistplus", new ServerListPlusCommand(), "slp");
@@ -368,12 +361,16 @@ public class VelocityPlugin implements ServerListPlusPlugin {
     }
 
     @Override
-    public void reloadFaviconCache(CacheBuilderSpec spec) {
-        if (spec != null) {
-            faviconCache.reload(spec);
+    public void createFaviconCache(CacheBuilderSpec spec) {
+        if (faviconCache == null) {
+            faviconCache = new FaviconCache<Favicon>(core, spec) {
+                @Override
+                protected Favicon createFavicon(BufferedImage image) throws Exception {
+                    return Favicon.create(image);
+                }
+            };
         } else {
-            // Delete favicon cache
-            faviconCache.clear();
+            faviconCache.reload(spec);
         }
     }
 

--- a/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
@@ -41,6 +41,7 @@ import net.minecrell.serverlistplus.core.config.CoreConf;
 import net.minecrell.serverlistplus.core.config.PluginConf;
 import net.minecrell.serverlistplus.core.config.ServerStatusConf;
 import net.minecrell.serverlistplus.core.config.help.Examples;
+import net.minecrell.serverlistplus.core.favicon.FaviconCache;
 import net.minecrell.serverlistplus.core.logging.Logger;
 import net.minecrell.serverlistplus.core.logging.ServerListPlusLogger;
 import net.minecrell.serverlistplus.core.player.IdentificationStorage;
@@ -231,7 +232,8 @@ public class ServerListPlusCore {
             "favicons", new Function<ServerListPlusCore, Cache<?, ?>>() {
                 @Override
                 public Cache<?, ?> apply(ServerListPlusCore core) {
-                    return core.getPlugin().getFaviconCache();
+                    FaviconCache<?> cache = core.getPlugin().getFaviconCache();
+                    return (cache == null) ? null : cache.getLoadingCache();
                 }
             }, "requests", new Function<ServerListPlusCore, Cache<?, ?>>() {
                 @Override

--- a/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
@@ -232,8 +232,7 @@ public class ServerListPlusCore {
             "favicons", new Function<ServerListPlusCore, Cache<?, ?>>() {
                 @Override
                 public Cache<?, ?> apply(ServerListPlusCore core) {
-                    FaviconCache<?> cache = core.getPlugin().getFaviconCache();
-                    return (cache == null) ? null : cache.getLoadingCache();
+                    return core.getPlugin().getFaviconCache().getLoadingCache();
                 }
             }, "requests", new Function<ServerListPlusCore, Cache<?, ?>>() {
                 @Override

--- a/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
@@ -170,7 +170,7 @@ public class ServerListPlusCore {
                 !faviconCacheConf.equals(conf.Caches.Favicon))) {
             if (plugin.getFaviconCache() != null) {
                 getLogger().log(DEBUG, "Deleting old favicon cache due to configuration changes.");
-                plugin.reloadFaviconCache(null); // Delete the old favicon cache
+                plugin.getFaviconCache().clear(); // Delete the old favicon cache
             }
 
             if (enabled) {
@@ -178,11 +178,11 @@ public class ServerListPlusCore {
 
                 try {
                     this.faviconCacheConf = conf.Caches.Favicon;
-                    plugin.reloadFaviconCache(CacheBuilderSpec.parse(faviconCacheConf));
+                    plugin.createFaviconCache(CacheBuilderSpec.parse(faviconCacheConf));
                 } catch (IllegalArgumentException e) {
                     getLogger().log(e, "Unable to create favicon cache using configuration settings.");
                     this.faviconCacheConf = getDefaultConf(CoreConf.class).Caches.Favicon;
-                    plugin.reloadFaviconCache(CacheBuilderSpec.parse(faviconCacheConf));
+                    plugin.createFaviconCache(CacheBuilderSpec.parse(faviconCacheConf));
                 }
 
                 getLogger().log(DEBUG, "Favicon cache created.");
@@ -232,7 +232,8 @@ public class ServerListPlusCore {
             "favicons", new Function<ServerListPlusCore, Cache<?, ?>>() {
                 @Override
                 public Cache<?, ?> apply(ServerListPlusCore core) {
-                    return core.getPlugin().getFaviconCache().getLoadingCache();
+                    FaviconCache<?> cache = core.getPlugin().getFaviconCache();
+                    return (cache == null) ? null : cache.getLoadingCache();
                 }
             }, "requests", new Function<ServerListPlusCore, Cache<?, ?>>() {
                 @Override

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
@@ -23,7 +23,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import net.minecrell.serverlistplus.core.ServerListPlusCore;
+import net.minecrell.serverlistplus.core.plugin.ServerListPlusPlugin;
 import net.minecrell.serverlistplus.core.util.Helper;
 
 import java.awt.image.BufferedImage;
@@ -32,7 +32,7 @@ import static net.minecrell.serverlistplus.core.logging.Logger.Level.DEBUG;
 import static net.minecrell.serverlistplus.core.logging.Logger.Level.WARN;
 
 public abstract class FaviconCache<T> {
-    private final ServerListPlusCore core;
+    private final ServerListPlusPlugin plugin;
     private LoadingCache<FaviconSource, Optional<T>> loadingCache;
 
     private final CacheLoader<FaviconSource, Optional<T>> cacheLoader =
@@ -41,9 +41,9 @@ public abstract class FaviconCache<T> {
             public Optional<T> load(FaviconSource source) throws Exception {
                 BufferedImage image;
                 try {
-                    image = FaviconHelper.load(core, source);
+                    image = FaviconHelper.load(plugin.getCore(), source);
                 } catch (Exception e) {
-                    core.getLogger()
+                    plugin.getCore().getLogger()
                         .log(WARN, "Unable to load favicon from {}: {} -> {}",
                             source.getLoader(), source.getSource(), Helper.causedException(e))
                         .log(DEBUG, e, "Unable to load favicon from {}: {}",
@@ -55,8 +55,8 @@ public abstract class FaviconCache<T> {
             }
         };
 
-    public FaviconCache(ServerListPlusCore core, CacheBuilderSpec spec) {
-        this.core = core;
+    public FaviconCache(ServerListPlusPlugin plugin, CacheBuilderSpec spec) {
+        this.plugin = plugin;
         reload(spec);
     }
 

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
@@ -32,55 +32,55 @@ import static net.minecrell.serverlistplus.core.logging.Logger.Level.DEBUG;
 import static net.minecrell.serverlistplus.core.logging.Logger.Level.WARN;
 
 public abstract class FaviconCache<T> {
-	private ServerListPlusCore core;
-	private LoadingCache<FaviconSource, Optional<T>> loadingCache;
+    private ServerListPlusCore core;
+    private LoadingCache<FaviconSource, Optional<T>> loadingCache;
 
-	private final CacheLoader<FaviconSource, Optional<T>> cacheLoader =
-		new CacheLoader<FaviconSource, Optional<T>>() {
-			@Override
-			public Optional<T> load(FaviconSource source) throws Exception {
-				BufferedImage image;
-				try {
-					image = FaviconHelper.load(core, source);
-				} catch (Exception e) {
-					core.getLogger()
-						.log(WARN, "Unable to load favicon from {}: {} -> {}",
-							source.getLoader(), source.getSource(), Helper.causedException(e))
-						.log(DEBUG, e, "Unable to load favicon from {}: {}",
-							source.getLoader(), source.getSource());
-					return Optional.absent();
-				}
+    private final CacheLoader<FaviconSource, Optional<T>> cacheLoader =
+        new CacheLoader<FaviconSource, Optional<T>>() {
+            @Override
+            public Optional<T> load(FaviconSource source) throws Exception {
+                BufferedImage image;
+                try {
+                    image = FaviconHelper.load(core, source);
+                } catch (Exception e) {
+                    core.getLogger()
+                        .log(WARN, "Unable to load favicon from {}: {} -> {}",
+                            source.getLoader(), source.getSource(), Helper.causedException(e))
+                        .log(DEBUG, e, "Unable to load favicon from {}: {}",
+                            source.getLoader(), source.getSource());
+                    return Optional.absent();
+                }
 
-				return Optional.of(createFavicon(image));
-			}
-		};
+                return Optional.of(createFavicon(image));
+            }
+        };
 
-	public void setCore(ServerListPlusCore core) {
-		this.core = core;
-	}
+    public void setCore(ServerListPlusCore core) {
+        this.core = core;
+    }
 
-	public Optional<T> get(FaviconSource source) {
-		return (loadingCache == null) ? Optional.<T>absent() : loadingCache.getUnchecked(source);
-	}
+    public Optional<T> get(FaviconSource source) {
+        return (loadingCache == null) ? Optional.<T>absent() : loadingCache.getUnchecked(source);
+    }
 
-	public boolean contains(FaviconSource source) {
-		return (loadingCache == null) ? false : (loadingCache.getIfPresent(source) != null);
-	}
+    public boolean contains(FaviconSource source) {
+        return (loadingCache == null) ? false : (loadingCache.getIfPresent(source) != null);
+    }
 
-	public LoadingCache<FaviconSource, Optional<T>> getLoadingCache() {
-		return loadingCache;
-	}
+    public LoadingCache<FaviconSource, Optional<T>> getLoadingCache() {
+        return loadingCache;
+    }
 
-	public void clear() {
-		if (loadingCache == null) return;
-		loadingCache.invalidateAll();
-		loadingCache.cleanUp();
-		loadingCache = null;
-	}
+    public void clear() {
+        if (loadingCache == null) return;
+        loadingCache.invalidateAll();
+        loadingCache.cleanUp();
+        loadingCache = null;
+    }
 
-	public void reload(CacheBuilderSpec spec) {
-		loadingCache = CacheBuilder.from(spec).build(cacheLoader);
-	}
+    public void reload(CacheBuilderSpec spec) {
+        loadingCache = CacheBuilder.from(spec).build(cacheLoader);
+    }
 
-	protected abstract T createFavicon(BufferedImage image) throws Exception;
+    protected abstract T createFavicon(BufferedImage image) throws Exception;
 }

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
@@ -64,8 +64,8 @@ public abstract class FaviconCache<T> {
         return loadingCache.getUnchecked(source);
     }
 
-    public boolean contains(FaviconSource source) {
-        return loadingCache.getIfPresent(source) != null;
+    public Optional<T> getIfPresent(FaviconSource source) {
+        return loadingCache.getIfPresent(source);
     }
 
     public LoadingCache<FaviconSource, Optional<T>> getLoadingCache() {

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
@@ -32,38 +32,39 @@ import static net.minecrell.serverlistplus.core.logging.Logger.Level.DEBUG;
 import static net.minecrell.serverlistplus.core.logging.Logger.Level.WARN;
 
 public abstract class FaviconCache<T> {
-	private final LoadingCache<FaviconSource, Optional<T>> loadingCache;
+	private ServerListPlusCore core;
+	private LoadingCache<FaviconSource, Optional<T>> loadingCache;
 
-	public FaviconCache(final ServerListPlusCore core, CacheBuilderSpec spec) {
-		CacheLoader<FaviconSource, Optional<T>> cacheLoader =
-			new CacheLoader<FaviconSource, Optional<T>>() {
-				@Override
-				public Optional<T> load(FaviconSource source) throws Exception {
-					BufferedImage image;
-					try {
-						image = FaviconHelper.load(core, source);
-					} catch (Exception e) {
-						core.getLogger()
-							.log(WARN, "Unable to load favicon from {}: {} -> {}",
-								source.getLoader(), source.getSource(), Helper.causedException(e))
-							.log(DEBUG, e, "Unable to load favicon from {}: {}",
-								source.getLoader(), source.getSource());
-						return Optional.absent();
-					}
-
-					return Optional.of(createFavicon(image));
+	private final CacheLoader<FaviconSource, Optional<T>> cacheLoader =
+		new CacheLoader<FaviconSource, Optional<T>>() {
+			@Override
+			public Optional<T> load(FaviconSource source) throws Exception {
+				BufferedImage image;
+				try {
+					image = FaviconHelper.load(core, source);
+				} catch (Exception e) {
+					core.getLogger()
+						.log(WARN, "Unable to load favicon from {}: {} -> {}",
+							source.getLoader(), source.getSource(), Helper.causedException(e))
+						.log(DEBUG, e, "Unable to load favicon from {}: {}",
+							source.getLoader(), source.getSource());
+					return Optional.absent();
 				}
-			};
 
-		loadingCache = CacheBuilder.from(spec).build(cacheLoader);
+				return Optional.of(createFavicon(image));
+			}
+		};
+
+	public void setCore(ServerListPlusCore core) {
+		this.core = core;
 	}
 
 	public Optional<T> get(FaviconSource source) {
-		return loadingCache.getUnchecked(source);
+		return (loadingCache == null) ? Optional.<T>absent() : loadingCache.getUnchecked(source);
 	}
 
 	public boolean contains(FaviconSource source) {
-		return loadingCache.getIfPresent(source) != null;
+		return (loadingCache == null) ? false : (loadingCache.getIfPresent(source) != null);
 	}
 
 	public LoadingCache<FaviconSource, Optional<T>> getLoadingCache() {
@@ -71,8 +72,14 @@ public abstract class FaviconCache<T> {
 	}
 
 	public void clear() {
+		if (loadingCache == null) return;
 		loadingCache.invalidateAll();
 		loadingCache.cleanUp();
+		loadingCache = null;
+	}
+
+	public void reload(CacheBuilderSpec spec) {
+		loadingCache = CacheBuilder.from(spec).build(cacheLoader);
 	}
 
 	protected abstract T createFavicon(BufferedImage image) throws Exception;

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
@@ -1,0 +1,79 @@
+/*
+ * ServerListPlus - https://git.io/slp
+ * Copyright (C) 2014 Minecrell (https://github.com/Minecrell)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.minecrell.serverlistplus.core.favicon;
+
+import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheBuilderSpec;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import net.minecrell.serverlistplus.core.ServerListPlusCore;
+import net.minecrell.serverlistplus.core.util.Helper;
+
+import java.awt.image.BufferedImage;
+
+import static net.minecrell.serverlistplus.core.logging.Logger.Level.DEBUG;
+import static net.minecrell.serverlistplus.core.logging.Logger.Level.WARN;
+
+public abstract class FaviconCache<T> {
+	private final LoadingCache<FaviconSource, Optional<T>> loadingCache;
+
+	public FaviconCache(final ServerListPlusCore core, CacheBuilderSpec spec) {
+		CacheLoader<FaviconSource, Optional<T>> cacheLoader =
+			new CacheLoader<FaviconSource, Optional<T>>() {
+				@Override
+				public Optional<T> load(FaviconSource source) throws Exception {
+					BufferedImage image;
+					try {
+						image = FaviconHelper.load(core, source);
+					} catch (Exception e) {
+						core.getLogger()
+							.log(WARN, "Unable to load favicon from {}: {} -> {}",
+								source.getLoader(), source.getSource(), Helper.causedException(e))
+							.log(DEBUG, e, "Unable to load favicon from {}: {}",
+								source.getLoader(), source.getSource());
+						return Optional.absent();
+					}
+
+					return Optional.of(createFavicon(image));
+				}
+			};
+
+		loadingCache = CacheBuilder.from(spec).build(cacheLoader);
+	}
+
+	public Optional<T> get(FaviconSource source) {
+		return loadingCache.getUnchecked(source);
+	}
+
+	public boolean contains(FaviconSource source) {
+		return loadingCache.getIfPresent(source) != null;
+	}
+
+	public LoadingCache<FaviconSource, Optional<T>> getLoadingCache() {
+		return loadingCache;
+	}
+
+	public void clear() {
+		loadingCache.invalidateAll();
+		loadingCache.cleanUp();
+	}
+
+	protected abstract T createFavicon(BufferedImage image) throws Exception;
+}

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconCache.java
@@ -32,7 +32,7 @@ import static net.minecrell.serverlistplus.core.logging.Logger.Level.DEBUG;
 import static net.minecrell.serverlistplus.core.logging.Logger.Level.WARN;
 
 public abstract class FaviconCache<T> {
-    private ServerListPlusCore core;
+    private final ServerListPlusCore core;
     private LoadingCache<FaviconSource, Optional<T>> loadingCache;
 
     private final CacheLoader<FaviconSource, Optional<T>> cacheLoader =
@@ -55,16 +55,17 @@ public abstract class FaviconCache<T> {
             }
         };
 
-    public void setCore(ServerListPlusCore core) {
+    public FaviconCache(ServerListPlusCore core, CacheBuilderSpec spec) {
         this.core = core;
+        reload(spec);
     }
 
     public Optional<T> get(FaviconSource source) {
-        return (loadingCache == null) ? Optional.<T>absent() : loadingCache.getUnchecked(source);
+        return loadingCache.getUnchecked(source);
     }
 
     public boolean contains(FaviconSource source) {
-        return (loadingCache == null) ? false : (loadingCache.getIfPresent(source) != null);
+        return loadingCache.getIfPresent(source) != null;
     }
 
     public LoadingCache<FaviconSource, Optional<T>> getLoadingCache() {
@@ -72,10 +73,8 @@ public abstract class FaviconCache<T> {
     }
 
     public void clear() {
-        if (loadingCache == null) return;
         loadingCache.invalidateAll();
         loadingCache.cleanUp();
-        loadingCache = null;
     }
 
     public void reload(CacheBuilderSpec spec) {

--- a/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconHelper.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/favicon/FaviconHelper.java
@@ -174,19 +174,6 @@ public final class FaviconHelper {
                 source.getSource()), FAVICON_SIZE, FAVICON_SIZE);
     }
 
-    public static BufferedImage loadSafely(ServerListPlusCore core, FaviconSource source) {
-        try { // Try loading the favicon
-            return load(core, source);
-        } catch (Exception e) {
-            core.getLogger()
-                    .log(WARN, "Unable to load favicon from {}: {} -> {}",
-                            source.getLoader(), source.getSource(), Helper.causedException(e))
-                    .log(DEBUG, e, "Unable to load favicon from {}: {}",
-                            source.getLoader(), source.getSource());
-            return null;
-        }
-    }
-
     private static boolean isSolidColor(BufferedImage image, int x, int y, int width, int height) {
         int base = image.getRGB(x, y);
         for (; x < width; x++) {

--- a/src/main/java/net/minecrell/serverlistplus/core/plugin/ServerListPlusPlugin.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/plugin/ServerListPlusPlugin.java
@@ -56,7 +56,7 @@ public interface ServerListPlusPlugin {
 
     void initialize(ServerListPlusCore core);
     void reloadCaches(ServerListPlusCore core);
-    void reloadFaviconCache(CacheBuilderSpec spec);
+    void createFaviconCache(CacheBuilderSpec spec);
     void configChanged(ServerListPlusCore core, InstanceStorage<Object> confs);
     void statusChanged(StatusManager status, boolean hasChanges);
 }

--- a/src/main/java/net/minecrell/serverlistplus/core/plugin/ServerListPlusPlugin.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/plugin/ServerListPlusPlugin.java
@@ -20,10 +20,9 @@ package net.minecrell.serverlistplus.core.plugin;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilderSpec;
-import com.google.common.cache.LoadingCache;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.config.storage.InstanceStorage;
-import net.minecrell.serverlistplus.core.favicon.FaviconSource;
+import net.minecrell.serverlistplus.core.favicon.FaviconCache;
 import net.minecrell.serverlistplus.core.replacement.rgb.RGBFormat;
 import net.minecrell.serverlistplus.core.status.StatusManager;
 
@@ -47,7 +46,7 @@ public interface ServerListPlusPlugin {
     Iterator<String> getRandomPlayers(String location);
 
     Cache<?, ?> getRequestCache();
-    LoadingCache<FaviconSource, ?> getFaviconCache();
+    FaviconCache<?> getFaviconCache();
 
     void runAsync(Runnable task);
     ScheduledTask scheduleAsync(Runnable task, long repeat, TimeUnit unit);


### PR DESCRIPTION
This new class wraps a "LoadingCache" object, which is used by each of the plugins to cache favicons.

As far as I can tell, the "FaviconHelper.loadSafely" method is only used by this favicon caching code, so I integrated the code from this method into the new FaviconCache class and deleted the method.