### PR TITLE
Use builder class for creating formatted chat messages

### DIFF
--- a/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/ServerListPlusCore.java
@@ -55,7 +55,7 @@ import net.minecrell.serverlistplus.core.profile.ProfileManager;
 import net.minecrell.serverlistplus.core.replacement.ReplacementManager;
 import net.minecrell.serverlistplus.core.status.StatusManager;
 import net.minecrell.serverlistplus.core.status.StatusRequest;
-import net.minecrell.serverlistplus.core.util.ChatFormat;
+import net.minecrell.serverlistplus.core.util.ChatBuilder;
 import net.minecrell.serverlistplus.core.util.Helper;
 
 import java.net.InetAddress;
@@ -215,14 +215,9 @@ public class ServerListPlusCore {
         return new StatusRequest(client, resolveClient(client));
     }
 
-    private static final String COMMAND_PREFIX_BASE = ChatFormat.GOLD + "[ServerListPlus] ";
-    private static final String COMMAND_PREFIX = COMMAND_PREFIX_BASE + ChatFormat.GRAY;
-    private static final String COMMAND_PREFIX_SUCCESS = COMMAND_PREFIX_BASE + ChatFormat.GREEN;
-    private static final String COMMAND_PREFIX_ERROR = COMMAND_PREFIX_BASE + ChatFormat.RED;
-
     private static final String ADMIN_PERMISSION = "serverlistplus.admin";
 
-    private static final String HELP_HEADER = ChatFormat.GOLD + "---- [ServerListPlus Help] ----";
+    private static final String HELP_HEADER = new ChatBuilder().gold().append("---- [ServerListPlus Help] ----").toString();
 
     private static final Set<String> SUB_COMMANDS = ImmutableSet.of("reload", "rl", "save", "enable", "disable",
             "clean", "info", "help");
@@ -240,6 +235,22 @@ public class ServerListPlusCore {
                 }
             });
 
+    private static ChatBuilder commandPrefixBase() {
+        return new ChatBuilder().gold().append("[ServerListPlus] ");
+    }
+
+    private static ChatBuilder commandPrefix() {
+        return commandPrefixBase().gray();
+    }
+
+    private static ChatBuilder commandPrefixError() {
+        return commandPrefixBase().red();
+    }
+
+    private static ChatBuilder commandPrefixSuccess() {
+        return commandPrefixBase().green();
+    }
+
     public void executeCommand(ServerCommandSender sender, String cmd, String[] args) {
         boolean admin = sender.hasPermission(ADMIN_PERMISSION);
 
@@ -248,54 +259,68 @@ public class ServerListPlusCore {
 
             if (!SUB_COMMANDS.contains(sub)) {
                 if (admin)
-                    sender.sendMessage(COMMAND_PREFIX + "Unknown command. Type " + ChatFormat.DARK_GRAY
-                            + "/slp help" + ChatFormat.GRAY + " for a list of available commands.");
+                    sender.sendMessage(commandPrefix()
+                        .append("Unknown command. Type ")
+                        .darkGray().append("/slp help")
+                        .gray().append(" for a list of available commands.").toString());
                 else
-                    sender.sendMessage(COMMAND_PREFIX + "Unknown command.");
+                    sender.sendMessage(commandPrefix().append("Unknown command.").toString());
                 return;
             }
 
             if (!admin)
-                sender.sendMessage(COMMAND_PREFIX_ERROR + "You do not have permission for this command.");
+                sender.sendMessage(commandPrefixError()
+                    .append("You do not have permission for this command.").toString());
 
             else if (sub.equals("reload") || sub.equals("rl")) {
-                sender.sendMessage(COMMAND_PREFIX + "Reloading configuration...");
+                sender.sendMessage(commandPrefix()
+                    .append("Reloading configuration...").toString());
 
                 try { // Reload the configuration
                     this.reload();
-                    sender.sendMessage(COMMAND_PREFIX_SUCCESS + "Configuration successfully reloaded!");
+                    sender.sendMessage(commandPrefixSuccess()
+                        .append("Configuration successfully reloaded!").toString());
                 } catch (ServerListPlusException e) {
-                    sender.sendMessage(COMMAND_PREFIX_ERROR + "An internal error occurred while reloading the " +
-                            "configuration.");
+                    sender.sendMessage(commandPrefixError()
+                        .append("An internal error occurred while reloading the configuration.").toString());
                 }
             } else if (sub.equals("save")) {
-                sender.sendMessage(COMMAND_PREFIX + "Saving configuration...");
+                sender.sendMessage(commandPrefix()
+                    .append("Saving configuration...").toString());
 
                 try { // Save the configuration
                     configManager.save();
                     ((JSONIdentificationStorage) storage).save();
-                    sender.sendMessage(COMMAND_PREFIX_SUCCESS + "Configuration successfully saved.");
+                    sender.sendMessage(commandPrefixSuccess()
+                        .append("Configuration successfully saved.").toString());
                 } catch (ServerListPlusException e) {
-                    sender.sendMessage(COMMAND_PREFIX_ERROR + "An internal error occurred while saving the " +
-                            "configuration.");
+                    sender.sendMessage(commandPrefixError()
+                        .append("An internal error occurred while saving the configuration.").toString());
                 }
             } else if (sub.equals("enable") || sub.equals("disable")) {
                 boolean enable = sub.equalsIgnoreCase("enable");
-                String tmp = enable ? "Enabling" : "Disabling";
-                sender.sendMessage(COMMAND_PREFIX + tmp + " ServerListPlus...");
+                sender.sendMessage(commandPrefix()
+                    .append(enable ? "Enabling" : "Disabling")
+                    .append(" ServerListPlus...").toString());
 
                 try { // Enable / disable the ServerListPlus profile
                     if (profileManager.setEnabled(enable)) {
-                        sender.sendMessage(COMMAND_PREFIX_SUCCESS + "ServerListPlus has been successfully " + (enable ?
-                                "enabled" : "disabled") + '!');
+                        sender.sendMessage(commandPrefixSuccess()
+                            .append("ServerListPlus has been successfully ")
+                            .append(enable ? "enabled" : "disabled")
+                            .append('!').toString());
                     } else {
                         enable = profileManager.isEnabled();
-                        sender.sendMessage(COMMAND_PREFIX_SUCCESS + "No changes. ServerListPlus is already " + (enable ?
-                                "enabled" : "disabled") + '!');
+                        sender.sendMessage(commandPrefixSuccess()
+                            .append("No changes. ServerListPlus is already ")
+                            .append(enable ? "enabled" : "disabled")
+                            .append('!').toString());
                     }
                 } catch (ServerListPlusException e) {
-                    sender.sendMessage(COMMAND_PREFIX_ERROR + "An internal error occurred while " +
-                            (enable ? "enabling" : "disabling") + " ServerListPlus.");
+                    sender.sendMessage(commandPrefixError()
+                        .append("An internal error occurred while ")
+                        .append(enable ? "enabling" : "disabling")
+                        .append(" ServerListPlus.").toString());
                 }
             } else if (sub.equals("clean")) {
                 if (args.length > 1) {
@@ -309,17 +334,22 @@ public class ServerListPlusCore {
                             cache.cleanUp();
                             getLogger().log(DEBUG, "Done.");
 
-                            sender.sendMessage(COMMAND_PREFIX_SUCCESS +
-                                    "Successfully cleaned up " + cacheName + " cache.");
+                            sender.sendMessage(commandPrefixSuccess()
+                                .append("Successfully cleaned up " + cacheName + " cache.").toString());
                         } else
-                            sender.sendMessage(COMMAND_PREFIX + "The " + cacheName + " cache is currently " +
-                                    "disabled. There is nothing to clean up.");
+                            sender.sendMessage(commandPrefix()
+                                .append("The " + cacheName + " cache is currently " +
+                                    "disabled. There is nothing to clean up.").toString());
                     } else
-                        sender.sendMessage(COMMAND_PREFIX_ERROR + "Unknown cache type. Type " + ChatFormat.DARK_RED
-                                + "/slp help" + ChatFormat.RED + " for more information.");
+                        sender.sendMessage(commandPrefixError()
+                            .append("Unknown cache type. Type ")
+                            .darkRed().append("/slp help")
+                            .red().append(" for more information.").toString());
                 } else
-                    sender.sendMessage(COMMAND_PREFIX_ERROR + "You need to specify the cache type. Type " +
-                            ChatFormat.DARK_RED + "/slp help" + ChatFormat.RED + " for more information.");
+                    sender.sendMessage(commandPrefixError()
+                        .append("You need to specify the cache type. Type ")
+                        .darkRed().append("/slp help")
+                        .red().append(" for more information.").toString());
             } else if (sub.equals("help")) {
                 sender.sendMessages(
                         HELP_HEADER,
@@ -337,19 +367,29 @@ public class ServerListPlusCore {
             return;
         }
         // Send the sender some information about the plugin
-        sender.sendMessage(ChatFormat.GOLD + this.getDisplayName());
+        sender.sendMessage(new ChatBuilder()
+            .gold().append(this.getDisplayName()).toString());
         if (info.getDescription() != null)
-            sender.sendMessage(ChatFormat.GRAY + info.getDescription());
+            sender.sendMessage(new ChatBuilder()
+                .gray().append(info.getDescription()).toString());
         if (info.getAuthor() != null)
-            sender.sendMessage(ChatFormat.GOLD + "Author: " + ChatFormat.GRAY + info.getAuthor());
+            sender.sendMessage(new ChatBuilder()
+                .gold().append("Author: ")
+                .gray().append(info.getAuthor()).toString());
         if (info.getWebsite() != null)
-            sender.sendMessage(ChatFormat.GOLD + "Website: " + ChatFormat.GRAY + info.getWebsite());
+            sender.sendMessage(new ChatBuilder()
+                .gold().append("Website: ")
+                .gray().append(info.getWebsite()).toString());
 
         if (admin) {
             if (info.getWiki() != null)
-                sender.sendMessage(ChatFormat.GOLD + "Wiki: " + ChatFormat.GRAY + info.getWiki());
-            sender.sendMessage(ChatFormat.GREEN + "Type " + ChatFormat.DARK_GREEN + "/slp help" + ChatFormat.GREEN
-                    + " for a list of available commands.");
+                sender.sendMessage(new ChatBuilder()
+                    .gold().append("Wiki: ")
+                    .gray().append(info.getWiki()).toString());
+            sender.sendMessage(new ChatBuilder()
+                .green().append("Type ")
+                .darkGreen().append("/slp help")
+                .green().append(" for a list of available commands.").toString());
         }
     }
 
@@ -371,11 +411,11 @@ public class ServerListPlusCore {
     }
 
     public static String buildCommandHelp(String cmd, String usage, String description) {
-        StringBuilder help = new StringBuilder();
-        help.append(ChatFormat.RED).append("/slp");
+        ChatBuilder help = new ChatBuilder();
+        help.red().append("/slp");
         if (cmd != null) help.append(' ').append(cmd);
-        if (usage != null) help.append(' ').append(ChatFormat.GOLD).append(usage);
-        return help.append(ChatFormat.WHITE).append(" - ").append(ChatFormat.GRAY).append(description).toString();
+        if (usage != null) help.append(' ').gold().append(usage);
+        return help.white().append(" - ").gray().append(description).toString();
     }
 
     public ConfigurationManager getConf() {

--- a/src/main/java/net/minecrell/serverlistplus/core/util/ChatBuilder.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/util/ChatBuilder.java
@@ -37,113 +37,91 @@ public class ChatBuilder implements CharSequence {
 	}
 
 	public ChatBuilder black() {
-		format('0');
-		return this;
+		return format('0');
 	}
 
 	public ChatBuilder darkBlue() {
-		format('1');
-		return this;
+		return format('1');
 	}
 
 	public ChatBuilder darkGreen() {
-		format('2');
-		return this;
+		return format('2');
 	}
 
 	public ChatBuilder darkAqua() {
-		format('3');
-		return this;
+		return format('3');
 	}
 
 	public ChatBuilder darkRed() {
-		format('4');
-		return this;
+		return format('4');
 	}
 
 	public ChatBuilder darkPurple() {
-		format('5');
-		return this;
+		return format('5');
 	}
 
 	public ChatBuilder gold() {
-		format('6');
-		return this;
+		return format('6');
 	}
 
 	public ChatBuilder gray() {
-		format('7');
-		return this;
+		return format('7');
 	}
 
 	public ChatBuilder darkGray() {
-		format('8');
-		return this;
+		return format('8');
 	}
 
 	public ChatBuilder blue() {
-		format('9');
-		return this;
+		return format('9');
 	}
 
 	public ChatBuilder green() {
-		format('a');
-		return this;
+		return format('a');
 	}
 
 	public ChatBuilder aqua() {
-		format('b');
-		return this;
+		return format('b');
 	}
 
 	public ChatBuilder red() {
-		format('c');
-		return this;
+		return format('c');
 	}
 
 	public ChatBuilder lightPurple() {
-		format('d');
-		return this;
+		return format('d');
 	}
 
 	public ChatBuilder yellow() {
-		format('e');
-		return this;
+		return format('e');
 	}
 
 	public ChatBuilder white() {
-		format('f');
-		return this;
+		return format('f');
 	}
 
 	public ChatBuilder obfuscated() {
-		format('k');
-		return this;
+		return format('k');
 	}
 
 	public ChatBuilder bold() {
-		format('l');
-		return this;
+		return format('l');
 	}
 
 	public ChatBuilder strikeThrough() {
-		format('m');
-		return this;
+		return format('m');
 	}
 
 	public ChatBuilder underline() {
-		format('n');
-		return this;
+		return format('n');
 	}
 
 	public ChatBuilder italic() {
-		format('o');
-		return this;
+		return format('o');
 	}
 
 	public ChatBuilder reset() {
-		format('r');
-		return this;
+		return format('r');
 	}
 
 	public ChatBuilder format(char c) {

--- a/src/main/java/net/minecrell/serverlistplus/core/util/ChatBuilder.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/util/ChatBuilder.java
@@ -1,0 +1,187 @@
+/*
+ * ServerListPlus - https://git.io/slp
+ * Copyright (C) 2014 Minecrell (https://github.com/Minecrell)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.minecrell.serverlistplus.core.util;
+
+public class ChatBuilder implements CharSequence {
+	private final StringBuilder sb = new StringBuilder();
+
+	public ChatBuilder append(CharSequence s) {
+		sb.append(s);
+		return this;
+	}
+
+	public ChatBuilder append(Object o) {
+		sb.append(o.toString());
+		return this;
+	}
+
+	public ChatBuilder append(char c) {
+		sb.append(c);
+		return this;
+	}
+
+	public ChatBuilder black() {
+		format('0');
+		return this;
+	}
+
+	public ChatBuilder darkBlue() {
+		format('1');
+		return this;
+	}
+
+	public ChatBuilder darkGreen() {
+		format('2');
+		return this;
+	}
+
+	public ChatBuilder darkAqua() {
+		format('3');
+		return this;
+	}
+
+	public ChatBuilder darkRed() {
+		format('4');
+		return this;
+	}
+
+	public ChatBuilder darkPurple() {
+		format('5');
+		return this;
+	}
+
+	public ChatBuilder gold() {
+		format('6');
+		return this;
+	}
+
+	public ChatBuilder gray() {
+		format('7');
+		return this;
+	}
+
+	public ChatBuilder darkGray() {
+		format('8');
+		return this;
+	}
+
+	public ChatBuilder blue() {
+		format('9');
+		return this;
+	}
+
+	public ChatBuilder green() {
+		format('a');
+		return this;
+	}
+
+	public ChatBuilder aqua() {
+		format('b');
+		return this;
+	}
+
+	public ChatBuilder red() {
+		format('c');
+		return this;
+	}
+
+	public ChatBuilder lightPurple() {
+		format('d');
+		return this;
+	}
+
+	public ChatBuilder yellow() {
+		format('e');
+		return this;
+	}
+
+	public ChatBuilder white() {
+		format('f');
+		return this;
+	}
+
+	public ChatBuilder obfuscated() {
+		format('k');
+		return this;
+	}
+
+	public ChatBuilder bold() {
+		format('l');
+		return this;
+	}
+
+	public ChatBuilder strikeThrough() {
+		format('m');
+		return this;
+	}
+
+	public ChatBuilder underline() {
+		format('n');
+		return this;
+	}
+
+	public ChatBuilder italic() {
+		format('o');
+		return this;
+	}
+
+	public ChatBuilder reset() {
+		format('r');
+		return this;
+	}
+
+	public ChatBuilder format(char c) {
+		return append('§').append(c);
+	}
+
+	@Override
+	public int length() {
+		return sb.length();
+	}
+
+	@Override
+	public char charAt(int index) {
+		return sb.charAt(index);
+	}
+
+	@Override
+	public CharSequence subSequence(int start, int end) {
+		return sb.subSequence(start, end);
+	}
+
+	@Override
+	public String toString() {
+		return sb.toString();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		ChatBuilder that = (ChatBuilder) o;
+		return sb.equals(that.sb);
+	}
+
+	@Override
+	public int hashCode() {
+		return sb.hashCode();
+	}
+}


### PR DESCRIPTION
The `ChatBuilder` class encapsulates everything related to chat message formatting into a single class. This class is especially useful when logic is involved in the building of a chat message (like in the `ServerListPlusCore.buildCommandHelp` method) because the `StringBuilder` object you would normally use is encapsulated inside of `ChatBuilder`. The builder pattern also makes coding a little easier by leveraging the IDE's autocomplete functionality.

Modifying the `ServerCommandSender.sendMessage()` method signature to accept a `CharSequence` instead of a `String` would eliminate the need to call `toString()` at the end of every message. Doing this would still allow you to pass `String` objects into the method because `String` implements `CharSequence`.