### PR TITLE
Update SnakeYAML to 2.0 and shade it

### DIFF
--- a/Server/build.gradle.kts
+++ b/Server/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
 
     // Note: Before upgrading these dependencies, make sure the core would also compile against them!
     implementation("com.google.guava:guava:31.1-jre")
-    implementation("org.yaml:snakeyaml:2.0")
     implementation("com.google.code.gson:gson:2.10.1")
 
     implementation(platform("net.kyori:adventure-bom:4.13.1"))

--- a/Server/build.gradle.kts
+++ b/Server/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
 
     // Note: Before upgrading these dependencies, make sure the core would also compile against them!
     implementation("com.google.guava:guava:31.1-jre")
-    implementation("org.yaml:snakeyaml:1.33")
+    implementation("org.yaml:snakeyaml:2.0")
     implementation("com.google.code.gson:gson:2.10.1")
 
     implementation(platform("net.kyori:adventure-bom:4.13.1"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,20 +82,17 @@ subprojects {
         archiveClassifier.set(project.name)
         duplicatesStrategy = DuplicatesStrategy.FAIL
 
-        dependencies {
-            include(dependency("org.yaml:snakeyaml"))
-        }
-        relocate("org.yaml.snakeyaml", "net.minecrell.serverlistplus.core.lib.snakeyaml")
-
         if (project.name != "Server") {
             exclude("META-INF/maven/", "META-INF/proguard/", "META-INF/services/")
 
             dependencies {
                 include(project(rootProject.path))
                 include(dependency("org.ocpsoft.prettytime:prettytime"))
+                include(dependency("org.yaml:snakeyaml"))
             }
 
             relocate("org.ocpsoft.prettytime", "net.minecrell.serverlistplus.core.lib.prettytime")
+            relocate("org.yaml.snakeyaml", "net.minecrell.serverlistplus.core.lib.snakeyaml")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,11 @@ subprojects {
         archiveClassifier.set(project.name)
         duplicatesStrategy = DuplicatesStrategy.FAIL
 
+        dependencies {
+            include(dependency("org.yaml:snakeyaml"))
+        }
+        relocate("org.yaml.snakeyaml", "net.minecrell.serverlistplus.core.lib.snakeyaml")
+
         if (project.name != "Server") {
             exclude("META-INF/maven/", "META-INF/proguard/", "META-INF/services/")
 
@@ -102,7 +107,7 @@ repositories {
 dependencies {
     implementation("com.google.guava:guava:21.0")
     implementation("com.google.code.gson:gson:2.8.0")
-    implementation("org.yaml:snakeyaml:1.19")
+    implementation("org.yaml:snakeyaml:2.0")
     implementation("org.ocpsoft.prettytime:prettytime:4.0.6.Final")
 
     compileOnly("org.slf4j:slf4j-api:1.7.25")

--- a/src/main/java/net/minecrell/serverlistplus/core/config/yaml/ConfigurationRepresenter.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/config/yaml/ConfigurationRepresenter.java
@@ -18,6 +18,7 @@
 
 package net.minecrell.serverlistplus.core.config.yaml;
 
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.nodes.Node;
 import org.yaml.snakeyaml.nodes.NodeId;
@@ -31,7 +32,8 @@ import java.util.Map;
 
 public class ConfigurationRepresenter extends Representer {
 
-    public ConfigurationRepresenter() {
+    public ConfigurationRepresenter(DumperOptions dumperOptions) {
+        super(dumperOptions);
         // Remove existing representers so we can add something in the beginning
         Map<Class<?>, Represent> backup = new LinkedHashMap<>(multiRepresenters);
         multiRepresenters.clear();

--- a/src/main/java/net/minecrell/serverlistplus/core/config/yaml/ServerListPlusYAML.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/config/yaml/ServerListPlusYAML.java
@@ -40,7 +40,7 @@ public final class ServerListPlusYAML {
 
         // Plugin classes are loaded from a different class loader, that's why we need this
         Constructor constructor = new UnknownConfigurationConstructor(core);
-        Representer representer = new ConfigurationRepresenter(); // Skip null properties
+        Representer representer = new ConfigurationRepresenter(dumperOptions); // Skip null properties
         representer.setPropertyUtils(new ConfigurationPropertyUtils(core));
 
         String[] header = null;

--- a/src/main/java/net/minecrell/serverlistplus/core/config/yaml/UnknownConfigurationConstructor.java
+++ b/src/main/java/net/minecrell/serverlistplus/core/config/yaml/UnknownConfigurationConstructor.java
@@ -23,6 +23,7 @@ import static net.minecrell.serverlistplus.core.logging.Logger.Level.WARN;
 import com.google.common.base.Throwables;
 import net.minecrell.serverlistplus.core.ServerListPlusCore;
 import net.minecrell.serverlistplus.core.config.UnknownConf;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor;
 import org.yaml.snakeyaml.error.YAMLException;
 import org.yaml.snakeyaml.nodes.Node;
@@ -31,7 +32,7 @@ public class UnknownConfigurationConstructor extends CustomClassLoaderConstructo
     private final ServerListPlusCore core;
 
     public UnknownConfigurationConstructor(ServerListPlusCore core) {
-        super(core.getClass().getClassLoader());
+        super(core.getClass().getClassLoader(), new LoaderOptions());
         this.core = core;
     }
 


### PR DESCRIPTION
Recently Spigot as well as BungeeCord updated their included SnakeYAML version to 2.0 in the 1.20 update making SLP no longer load.

(It fails with this error on latest BungeeCord:

```
12:50:33 [WARNUNG] Exception encountered when loading plugin: ServerListPlus
java.lang.NoSuchMethodError: 'void org.yaml.snakeyaml.constructor.CustomClassLoaderConstructor.<init>(java.lang.ClassLoader)'
    at net.minecrell.serverlistplus.core.config.yaml.UnknownConfigurationConstructor.<init>(UnknownConfigurationConstructor.java:34)
    at net.minecrell.serverlistplus.core.config.yaml.ServerListPlusYAML.createWriter(ServerListPlusYAML.java:42)
    at net.minecrell.serverlistplus.core.ConfigurationManager.<init>(ConfigurationManager.java:57)
    at net.minecrell.serverlistplus.core.ServerListPlusCore.<init>(ServerListPlusCore.java:130)
    at net.minecrell.serverlistplus.core.ServerListPlusCore.<init>(ServerListPlusCore.java:92)
    at net.minecrell.serverlistplus.bungee.BungeePlugin.onEnable(BungeePlugin.java:93)
    at net.md_5.bungee.api.plugin.PluginManager.enablePlugins(PluginManager.java:266)
    at net.md_5.bungee.BungeeCord.start(BungeeCord.java:295)
    at net.md_5.bungee.BungeeCordLauncher.main(BungeeCordLauncher.java:67)
    at net.md_5.bungee.Bootstrap.main(Bootstrap.java:15)
```
)

This change both updates to SnakeYAML 2.0 as well as shades SnakeYAML directly into the resulting jars to avoid such issues in the future.

Technically the shading would only need to be done on platforms that don't ship SnakeYAML 2.0 yet (e.g. Velocity) but imo this is bad design: SnakeYAML is an implementation-detail of the different configuration APIs of those platforms and shouldn't be considered to be ever present in a specific version. As SLP directly uses it it should also provide it itself.